### PR TITLE
fix: support exports field in tsconfig lookup

### DIFF
--- a/src/ts-compiler-types.ts
+++ b/src/ts-compiler-types.ts
@@ -92,6 +92,13 @@ export interface TSInternal {
     message: _ts.DiagnosticMessage,
     ...args: (string | number | undefined)[]
   ): _ts.Diagnostic;
+  // Added in TS 5.0
+  nodeNextJsonConfigResolver(
+    moduleName: string,
+    containingFile: string,
+    host: _ts.ModuleResolutionHost
+  ): _ts.ResolvedModuleWithFailedLookupLocations;
+  // Replaced by nodeNextJsonConfigResolver in TS 5.0
   nodeModuleNameResolver(
     moduleName: string,
     containingFile: string,
@@ -99,7 +106,6 @@ export interface TSInternal {
     host: _ts.ModuleResolutionHost,
     cache?: _ts.ModuleResolutionCache,
     redirectedReference?: _ts.ResolvedProjectReference,
-    conditionsOrIsConfigLookup?: string[] | boolean, // `conditions` parameter added in TS 5.3
     isConfigLookup?: boolean
   ): _ts.ResolvedModuleWithFailedLookupLocations;
   // Added in TS 4.7

--- a/src/ts-internals.ts
+++ b/src/ts-internals.ts
@@ -1,7 +1,7 @@
-import { isAbsolute, resolve } from 'path';
-import { cachedLookup, normalizeSlashes, versionGteLt } from './util';
+import {isAbsolute, resolve} from 'path';
+import {cachedLookup, normalizeSlashes, versionGteLt} from './util';
 import type * as _ts from 'typescript';
-import type { TSCommon, TSInternal } from './ts-compiler-types';
+import type {TSCommon, TSInternal} from './ts-compiler-types';
 
 /** @internal */
 export const createTsInternals = cachedLookup(createTsInternalsUncached);
@@ -55,17 +55,18 @@ function createTsInternalsUncached(_ts: TSCommon) {
       return extendedConfigPath;
     }
     // If the path isn't a rooted or relative path, resolve like a module
-    const tsGte5_3_0 = versionGteLt(ts.version, '5.3.0');
-    const resolved = ts.nodeModuleNameResolver(
-      extendedConfig,
-      combinePaths(basePath, 'tsconfig.json'),
-      { moduleResolution: ts.ModuleResolutionKind.NodeJs },
-      host,
-      /*cache*/ undefined,
-      /*projectRefs*/ undefined,
-      /*conditionsOrIsConfigLookup*/ tsGte5_3_0 ? undefined : true,
-      /*isConfigLookup*/ tsGte5_3_0 ? true : undefined
-    );
+    const tsGte5_0_0 = versionGteLt(ts.version, '5.0.0');
+    const resolved = tsGte5_0_0
+      ? ts.nodeNextJsonConfigResolver(extendedConfig, combinePaths(basePath, 'tsconfig.json'), host)
+      : ts.nodeModuleNameResolver(
+        extendedConfig,
+        combinePaths(basePath, 'tsconfig.json'),
+        { moduleResolution: ts.ModuleResolutionKind.NodeJs },
+        host,
+        /*cache*/ undefined,
+        /*projectRefs*/ undefined,
+        /*isConfigLookup*/ true,
+      );
     if (resolved.resolvedModule) {
       return resolved.resolvedModule.resolvedFileName;
     }


### PR DESCRIPTION
Use another internal TS API that was added in v5.0

Refs: https://github.com/microsoft/TypeScript/pull/50955
